### PR TITLE
Configure kubectl on the host machine via the certs generated from tf

### DIFF
--- a/terraform/digitalocean/.gitignore
+++ b/terraform/digitalocean/.gitignore
@@ -1,3 +1,4 @@
 id_rsa
 id_rsa.pub
 etcd_discovery_url.txt
+*.pem


### PR DESCRIPTION
Assumes that kubectl is already installed and in your $PATH. Should we attempt to install that here or leave it for instructions / elsewhere?
