### PR TITLE
initial commit of wercker gitbook support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "devDependencies": {
     "gitbook-cli": "^0.3.4",
-    "rimraf": "^2.3.4"
+    "gitbook-plugin-edit-link": "^1.4.2",
+    "gitbook-plugin-github": "^1.1.0",
+    "gitbook-plugin-prism": "^1.0.0",
+    "rimraf": "^2.5.2"
   }
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -30,9 +30,14 @@ deploy:
     id: node:4-slim
 
   steps:
+    - install-packages:
+        packages: git
     - npm-install:
-        options: -g
+        options: -g rimraf gitbook-cli
     - script:
-        name: generate docs
+        name: Generate docs
         code: |
-          npm run docs:publish
+          npm run docs:build
+    - lukevivier/gh-pages:
+        token: $GITHUB_TOKEN
+        basedir: _book

--- a/wercker.yml
+++ b/wercker.yml
@@ -10,7 +10,7 @@ build:
         name: run ansible-lint against the site.yml playbook
         playbook: site.yml
     - capgemini/terraform-install:
-        version: 0.6.12
+        version: 0.6.16
     - script:
         name: terraform validate
         code: |
@@ -23,3 +23,16 @@ build:
           echo localhost > wercker_inventory
           ansible-galaxy install --force -r requirements.yml
           ansible-playbook -i wercker_inventory --syntax-check site.yml
+
+deploy:
+  # Override the python:2.7 box
+  box:
+    id: node:4-slim
+
+  steps:
+    - npm-install:
+        options: -g
+    - script:
+        name: generate docs
+        code: |
+          npm run docs:publish


### PR DESCRIPTION
Generates the following error (on ```npm run docs:publish```) - 

```
> kubeform@0.0.1 docs:clean /pipeline/source
> rimraf _book

sh: 1: rimraf: not found
```

even though the previous step ```npm install``` worked out OK.