### PR TITLE
Aws_public_subnet module pooling not fixed to a certain version

### DIFF
--- a/terraform/aws/public-cloud/main.tf
+++ b/terraform/aws/public-cloud/main.tf
@@ -134,7 +134,7 @@ module "igw" {
 
 # public subnets
 module "public_subnet" {
-  source = "github.com/terraform-community-modules/tf_aws_public_subnet"
+  source = "github.com/terraform-community-modules/tf_aws_public_subnet?ref=b7659c06cba6a545b83f569bc73560b266e6c9c1"
   name   = "public"
   cidrs  = "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24"
   azs    = "${var.availability_zones}"


### PR DESCRIPTION
Well just an update of the main.tf which contain the url of the module Aws_public_subnet. 
This module wasn't compatible anymore and so i just fixed the source to a certain commit. 